### PR TITLE
Update rollup-plugin-svelte to 6.1.1

### DIFF
--- a/my_component/frontend/package.json
+++ b/my_component/frontend/package.json
@@ -12,7 +12,7 @@
     "@rollup/plugin-node-resolve": "^8.0.0",
     "rollup": "^2.3.4",
     "rollup-plugin-livereload": "^1.0.0",
-    "rollup-plugin-svelte": "^5.0.3",
+    "rollup-plugin-svelte": "^6.1.1",
     "rollup-plugin-terser": "^5.1.2",
     "svelte": "^3.0.0",
     "svelte-check": "^1.0.0",


### PR DESCRIPTION
The current version of the code on master suffers the issue https://github.com/sveltejs/svelte/issues/5665
This PR tries to address that with a package update.